### PR TITLE
Delete Real World example from Nested List

### DIFF
--- a/src/documents/examples/nested-list/real-world.html.eco
+++ b/src/documents/examples/nested-list/real-world.html.eco
@@ -1,9 +1,0 @@
----
-title: Real World Example
-layout: single-example
-slug: 'nested-list'
-tags: 'nested-list'
-category: Nested List
----
-
-<p>For a more involved example, check out the <a href="../form-builder/">Form Builder</a> examples!</p>


### PR DESCRIPTION
Deleted "Real World" example from Nested List module. Example linked to another module not supported in 1.0.x.
