### PR TITLE
Remove 'Fork me on Github' banner

### DIFF
--- a/src/files/website/css/main.css
+++ b/src/files/website/css/main.css
@@ -126,21 +126,6 @@ pre {
   position: relative;
 }
 
-/* Github Ribbon */
-
-.github-ribbon {
-  position: fixed;
-  top: 0;
-  right: 0;
-  border: 0;
-  z-index: 404;
-}
-
-
-@media only screen and (max-width: 1048px) {
-  .github-ribbon { display: none; }
-}
-
 /* Nav */
 
 .navbar {

--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -47,10 +47,6 @@
 
   <div id="wrap">
 
-    <a class="github-ribbon" href="<%= @site.githubUrl %>">
-      <img src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub">
-    </a>
-
     <div class="navbar navbar-inverse navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">


### PR DESCRIPTION
Removed the "Fork me" banner from the right side of the navbar. 1.5 has it, but 2.0 doesn't.
